### PR TITLE
Fix the links in the Contents section for videos and articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ These are the main topics of this Awesome Kubernetes (K8s) Security List. Everyt
 
 - [💊 The Basics](#basics)
 - [💼 Official Pages](#official)
-- [📹 Talks and Videos](#videos)
-- [📰 Blogs and Articles](#blogs-articles)
+- [📹 Talks and Videos](#talks-and-videos)
+- [📰 Blogs and Articles](#blogs-and-articles)
 - [🗒️ Books](#books)
 - [📆 Certifications](#certifications)
 - [🔥 CVEs](#cves)


### PR DESCRIPTION
As the title says, the links were not correct.