### PR TITLE
Add segspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [Kubescape - Kubernetes is deployed securely according to NSA-CISA and the MITRE ATT&CK® frameworks](https://github.com/armosec/kubescape)
 
+[segspec - Extract network dependencies from app configs and generate Kubernetes NetworkPolicies](https://github.com/dormstern/segspec)
+
 [KubiScan](https://github.com/cyberark/KubiScan)
 
 [Kubernetes Audit by Trail of Bits](https://github.com/trailofbits/audit-kubernetes)


### PR DESCRIPTION
Add [segspec](https://github.com/dormstern/segspec) to the Defending section.

segspec is an open-source CLI that extracts network dependencies from application config files (Spring, Docker Compose, K8s manifests, Helm, .env, Maven/Gradle) and generates Kubernetes NetworkPolicies. Each dependency is traced to the exact config line that declared it. MIT license, single Go binary.