### PR TITLE
Add ReleaseRun K8s Deprecation Checker to Defending tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [M9sweeper - Kubernetes Security Platform](https://github.com/m9sweeper/m9sweeper)
 
+[ReleaseRun K8s Deprecation Checker - Scan Kubernetes YAML manifests for deprecated and removed APIs with auto-fix suggestions](https://releaserun.com/tools/k8s-deprecation-checker/)
+
 ## Papers
 
 [Kubernetes Security Assessment - Final Report - May 2019](https://github.com/kubernetes/community/blob/master/sig-security/security-audit-2019/findings/Kubernetes%20Final%20Report.pdf)


### PR DESCRIPTION
Adds [ReleaseRun K8s Deprecation Checker](https://releaserun.com/tools/k8s-deprecation-checker/) to the Defending section under Repositories / Tools.

A free tool that scans Kubernetes YAML manifests for deprecated and removed API versions. It covers 98 deprecation rules across Kubernetes 1.16 through 1.32, flags which APIs have been removed vs deprecated, and generates corrected YAML with the updated apiVersion/kind replacements.

Useful for pre-upgrade audits and CI pipelines to catch deprecated APIs before they break during a cluster upgrade. Complements tools like kube-linter and kubescape that focus on security posture rather than API compatibility.