### PR TITLE
Add free self-study courses to Certifications section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,17 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 - [CKAD](https://www.cncf.io/certification/ckad/)
 
+- [CKAD Self-Study Course](https://rx-m.com/ckad-online-self-study-training-certification/) - free course to practice for the CKAD exam
+
 - [CKA](https://www.cncf.io/certification/cka/)
 
 - [Certified Kubernetes Administrator (CKA) Course](https://github.com/kodekloudhub/certified-kubernetes-administrator-course)
 
+- [CKA Self-Study Course](https://rx-m.com/cka-online-training/) - free course to practice for the CKA exam
+
 - [CKS](https://www.cncf.io/certification/cks/)
+
+- [CKS Self-Study Course](https://rx-m.com/cks-self-study-course/) - free course to practice for the CKS exam
 
 - [Certified Cloud Native Security Expert - CCNSE](https://www.practical-devsecops.com/certified-cloud-native-security-expert/)
 


### PR DESCRIPTION
This commit adds 3 links to the Certifications section of the README. The links are to free web-based self-study courses for the CKAD, CKA, and CKS that are kept up-to-date with the latest versions of the exams.