### PR TITLE
Add ReleaseRun K8s YAML Security Linter to Defending section

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ To understand about Kubernetes Security you first need to understand the basics 
 [falco](https://github.com/falcosecurity/falco)
 
 [kubesec](https://github.com/controlplaneio/kubesec)
+[ReleaseRun K8s YAML Security Linter - Paste any Kubernetes manifest for an instant A-F security grade with 12 checks: resource limits, runAsNonRoot, privilege escalation, hardcoded secrets, host networking and more](https://releaserun.com/tools/kubernetes-security-linter/)
 
 [kube-bench](https://github.com/aquasecurity/kube-bench)
 


### PR DESCRIPTION
## What this PR adds

Adds **[ReleaseRun K8s YAML Security Linter](https://releaserun.com/tools/kubernetes-security-linter/)** to the Defending section.

**What it does:** Paste any Kubernetes YAML manifest and get an instant A-F security grade. Checks 12 security rules:
- Missing resource limits/requests (CPU + memory)
- `runAsNonRoot` missing
- Containers running as root (UID 0)
- `allowPrivilegeEscalation` not set to false
- `readOnlyRootFilesystem` not set
- Linux capabilities not dropped (ALL)
- `hostNetwork`/`hostPID` enabled
- Hardcoded secrets in env vars (`password`, `secret`, `key`, `token`)
- Missing readiness/liveness probes
- `seccompProfile` not set

**Format:** Free web tool, client-side only, no signup. Complements existing CLI tools like kubesec and kubeaudit with a zero-install browser interface. Three bundled examples: Insecure→F, Partial→B, Hardened→A.

The K8s Deprecation Checker from ReleaseRun is already listed — adding the companion security linter.