### PR TITLE
Add Defensia — WAF + IDS for K8s nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper)
 
+[Defensia - WAF, intrusion detection, and automated blocking for Kubernetes nodes and Linux servers](https://github.com/defensia/agent)
+
 [falco](https://github.com/falcosecurity/falco)
 
 [kubesec](https://github.com/controlplaneio/kubesec)


### PR DESCRIPTION
Adds [Defensia](https://github.com/defensia/agent) to the **Defending** section.

**What it does:** Lightweight Go agent that deploys as a DaemonSet and protects Kubernetes nodes with:
- Ingress WAF (reads nginx-ingress logs, detects OWASP attacks)
- Pod event monitoring (CrashLoop, OOMKill, evictions)
- NetworkPolicy audit (detects namespaces without policies)
- SSH brute force detection (15 patterns)
- CVE scanning (NVD + EPSS + CISA KEV)
- Automatic IP blocking via iptables/ipset

**Install:** `helm install defensia-agent oci://ghcr.io/defensia/charts/defensia-agent --set token=TOKEN`

Open source (MIT), written in Go, ~33MB K8s binary.