### PR TITLE
Add MANTIS IaC Scanner to Repositories / Tools > Defending

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [KICS - Keeping Infrastructure as Code Secure](https://github.com/Checkmarx/kics)
 
+[MANTIS IaC Scanner - Browser-based Kubernetes manifest misconfig scanner; rule engine runs entirely client-side, no upload, no signup](https://mantiscore.ai/free-tools/iac-scan)
+
 [cnspec - cloud-native security and policy project](https://cnspec.io)
 
 [M9sweeper - Kubernetes Security Platform](https://github.com/m9sweeper/m9sweeper)


### PR DESCRIPTION
Adding **MANTIS IaC Scanner** (https://mantiscore.ai/free-tools/iac-scan) to the **Defending** section, slotted next to KICS since they're closest peers.

Why I think it fits this list specifically:

- **Kubernetes-first.** The scanner's rule set covers the common K8s misconfig classes — privileged containers, `hostNetwork`/`hostPID`, missing `securityContext`, capabilities ALL, missing resource limits, runAsRoot, etc. — across raw manifests and multi-doc YAML.
- **Client-side execution.** The whole rule engine runs in the browser via JS. Your manifest never leaves the page, which matters when scanning prod cluster configs you can't legally upload.
- **No signup, no email gate.** Open the page, drop the file, get results.
- **Hosted SaaS.** Format consistent with existing entries like ReleaseRun K8s YAML Security Linter, cnspec, and m9sweeper that link to product pages rather than GitHub repos.

Other formats supported alongside K8s in the same scanner: CloudFormation, Terraform, docker-compose, GitHub Actions — but the K8s ruleset is the original use case.