### PR TITLE
Add Darkmoon to Repositories/Tools > Attacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 ### Attacking
 
+[Darkmoon](https://github.com/ASCIT31/Dark-Moon)
+
 [kdigger](https://github.com/quarkslab/kdigger)
 
 [kube-hunter](https://github.com/aquasecurity/kube-hunter)


### PR DESCRIPTION
Darkmoon is an open source (GPL-3.0) autonomous AI penetration testing platform with strong Kubernetes coverage, orchestrating 80+ offensive tools through Markdown playbooks. It belongs in the Attacking subsection alongside kube-hunter, kubesploit and Peirates. https://github.com/ASCIT31/Dark-Moon