### PR TITLE
Add k8s-audit to Defending tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [PII-Shield - Zero-code log sanitization sidecar for Kubernetes that redacts PII from logs](https://github.com/pii-shield/pii-shield)
 
+[k8s-audit - Fast, dependency-light Kubernetes security audit using only kubectl and jq, mapped to a 50-point checklist](https://github.com/k8s-security-pro/k8s-audit)
+
 ## Papers
 
 [Kubernetes Security Assessment - Final Report - May 2019](https://github.com/kubernetes/community/blob/master/sig-security/security-audit-2019/findings/Kubernetes%20Final%20Report.pdf)


### PR DESCRIPTION
Adds k8s-audit to the Defending tools section — a small MIT-licensed, read-only Kubernetes security audit script using only kubectl + jq (no agents, nothing deployed in-cluster). It runs ~16 high-signal checks (privileged containers, missing NetworkPolicies, wildcard RBAC, :latest images, hostPath mounts, SA-token automount, etc.) and maps each finding to a numbered checklist item. Complements deeper scanners like kube-bench/Kubescape as a fast first pass.

Disclosure: I maintain the tool.