### PR TITLE
Add OCP Pipeline Lab to Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [Kube Security Lab: Learn from Kuberenetes attacks using Ansible and KinD](https://github.com/raesene/kube_security_lab)
 
+[OCP Pipeline Lab: Learn enterprise OpenShift supply-chain controls — CRQ gate, unprivileged buildah, manual promotion — on one laptop](https://github.com/ryanGTR/ocp-pipeline-lab)
+
 ### Attacking
 
 [kdigger](https://github.com/quarkslab/kdigger)


### PR DESCRIPTION
Adds a self-hosted lab that reproduces an enterprise OpenShift delivery chain (Jenkins → Tekton → Harbor → GitOps) on a single laptop, focused on the supply-chain controls: change-request gate, unprivileged buildah builds, and manual promotion between a staging and a release project. Fully scripted and re-runnable; QUICKSTART gets you to a green pipeline in ~15 min.

Disclosure: I'm the author.