### PR TITLE
Add rbac-auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [PII-Shield - Zero-code log sanitization sidecar for Kubernetes that redacts PII from logs](https://github.com/pii-shield/pii-shield)
 
+[rbac-auditor](https://github.com/fabiocicerchia/rbac-auditor) - Dumps and diffs Kubernetes RBAC: wildcard grants, cluster-admin bindings, unused SAs, who-can queries.
+
 ## Papers
 
 [Kubernetes Security Assessment - Final Report - May 2019](https://github.com/kubernetes/community/blob/master/sig-security/security-audit-2019/findings/Kubernetes%20Final%20Report.pdf)


### PR DESCRIPTION
Adds [rbac-auditor](https://github.com/fabiocicerchia/rbac-auditor) under **Defending**.

> Dumps and diffs Kubernetes RBAC: wildcard grants, cluster-admin bindings, unused SAs, who-can queries.

One addition in a single commit, formatted and ordered to match the surrounding entries in that section.