### PR TITLE
Add cosign-verify-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ To understand about Kubernetes Security you first need to understand the basics 
 
 [PII-Shield - Zero-code log sanitization sidecar for Kubernetes that redacts PII from logs](https://github.com/pii-shield/pii-shield)
 
+[cosign-verify-init](https://github.com/fabiocicerchia/cosign-verify-init) - Kubernetes init container that verifies cosign image signatures before the workload starts.
+
 ## Papers
 
 [Kubernetes Security Assessment - Final Report - May 2019](https://github.com/kubernetes/community/blob/master/sig-security/security-audit-2019/findings/Kubernetes%20Final%20Report.pdf)


### PR DESCRIPTION
Adds [cosign-verify-init](https://github.com/fabiocicerchia/cosign-verify-init) under **Defending**.

> Kubernetes init container that verifies cosign image signatures before the workload starts.

Disclosure: I am the author of this project.

One addition in a single commit, formatted and ordered to match the surrounding entries in that section.